### PR TITLE
ブログ投稿の削除

### DIFF
--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -42,5 +42,11 @@ class PostController extends Controller
         
         return redirect('/posts/' . $post->id);
     }
+    
+    public function delete(Post $post)
+    {
+        $post->delete();
+        return redirect('/');
+    }
 }
 ?>

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -4,9 +4,11 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 class Post extends Model
 {
+    use SoftDeletes;
     protected $fillable = [
         'title',
         'body',

--- a/resources/views/posts/index.blade.php
+++ b/resources/views/posts/index.blade.php
@@ -13,14 +13,28 @@
             @foreach ($posts as $post)
                 <div class='post'>
                     <h2 class='title'>
-                        <a href="/posts/{{$post->id}}">{{ $post->title }}</a>
+                        <a href="/posts/{{ $post->id }}">{{ $post->title }}</a>
                     </h2>
-                    <p class='body'>{{$post->body}}</p>
+                    <p class='body'>{{ $post->body }}</p>
+                    <form action="/posts/{{ $post->id }}" id="form_{{ $post->id }}" method="post">
+                        @csrf
+                        @method('DELETE')
+                        <button type="button" onclick="deletePost({{ $post->id }})">delete</button>
+                    </form>
                 </div>
             @endforeach
         </div>
         <div class='paginate'>
             {{ $posts->links() }}
         </div>
+        <script>
+            function deletePost(id) {
+                'use strict'
+                
+                if (confirm('削除すると復元できません。\n本当に削除しますか？')) {
+                    document.getElementById(`form_${id}`).submit();
+                }
+            }
+        </script>
     </body>
 </html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -35,3 +35,5 @@ Route::get('/posts/{post}', [PostController::class ,'show']);
 Route::get('/posts/{post}/edit', [PostController::class, 'edit']);
 
 Route::put('posts/{post}', [Postcontroller::class, 'update']);
+
+Route::delete('/posts/{post}', [PostController::class, 'delete']);


### PR DESCRIPTION
[ブログ投稿削除処理の実装]
[ブログ投稿削除関連のルーティング追加]
[ブログ投稿一覧画面へのブログ投稿削除実行用導線追加]
[ブログ投稿削除実行用のコントローラー実装]
[ブログ投稿用モデルクラス修正]
[動作確認]